### PR TITLE
Application deletion failure in tenant mode issue fix

### DIFF
--- a/modules/apps/publisher/apis/v1/asset_api_router.jag
+++ b/modules/apps/publisher/apis/v1/asset_api_router.jag
@@ -175,7 +175,7 @@ require('/modules/publisher.js').exec(function(ctx) {
         var msg={};
         var artifactManager = rxtManager.getArtifactManager(shortName);
         var server  = require('store').server;
-        var username = server.current(session).username;
+        var username = jagg.getUser().username;
 
         try {
             //Get the original artifact


### PR DESCRIPTION
Provide fix for https://wso2.org/jira/browse/APPM-257. 
(In tenant mode, the username which was read from session objects returns username value without the domain name. In the fix, the username is extracted from the jagg.getUser() method.)
