### PR TITLE
Fixing NPE on pagination on Discovery and pagination failure.

### DIFF
--- a/modules/jaggery-apps/app-publisher-web/assets/default/app_discover.jag
+++ b/modules/jaggery-apps/app-publisher-web/assets/default/app_discover.jag
@@ -190,7 +190,7 @@ routeMnger.register('GET', 'publisher', '/publisher/assets/{operation}/{type}/',
             if(discoverClient != null && sessionData != null) {
                 var appsWrapper = discoverClient.discoverWebapps(sessionData.serverUrl,
                                 sessionData.serverUserName, null, currIndex, sessionData.appStatus,
-                                sessionData.appNameStartsWith);
+                                sessionData.appNameStartsWith, api.getLoggedInUser(session));
                 discoveredArtifacts = appsWrapper.metadataList;
                 status = appsWrapper.status;
                 createPaginationInfo(appsWrapper, sessionData, currIndex);


### PR DESCRIPTION
There is be a bug in pack on 20-04-2015 in which the application discovery pagination will not function properly. Console log also spits out NullPointer Exception. This will fix that issue.
