### PR TITLE
Test for Fix: discovery failing when the app server services url does not end with Slash

### DIFF
--- a/modules/integration/tests-ui/src/test/java/org/wso2/carbon/appmanager/integration/ui/TestCases/AppDiscoveryUITestCase.java
+++ b/modules/integration/tests-ui/src/test/java/org/wso2/carbon/appmanager/integration/ui/TestCases/AppDiscoveryUITestCase.java
@@ -85,8 +85,6 @@ public class AppDiscoveryUITestCase extends APPManagerIntegrationTest {
         waitForHttpGet(appServerServiceUrl + "WebappAdmin?wsdl", 200, 30000L);
     }
 
-    //Init method  appmPublisherUIClient = new APPMPublisherUIClient();
-
     /**
      * Tests the discovery application listing
      * @throws Exception
@@ -94,6 +92,23 @@ public class AppDiscoveryUITestCase extends APPManagerIntegrationTest {
     @Test(groups = { "wso2.appmanager.discovery" }, description = "Tests Discovery app listing",
             sequential = true, priority = 4)
     public void testDiscoverListing() throws Exception {
+        performInitialDiscovery();
+
+        String status = webDriverForPublisher.findElement(By.className("info-div"))
+                .findElement(By.tagName("span")).getText();
+        assertContains(status, INFO_SUCCESS_DISCOVERY_START_WITH,
+                "The status in info box should be \"" + INFO_SUCCESS_DISCOVERY_START_WITH + "\"");
+    }
+
+    /**
+     * Tests the discovery application listing, with the app server URL not ending with "\"
+     * @throws Exception
+     */
+    @Test(groups = { "wso2.appmanager.discovery" }, description = "Tests Discovery app listing",
+            sequential = true, priority = 4)
+    public void testDiscoverListing_AsUrlNotEndingWithSlash() throws Exception {
+        //Remove the trailing "/" from the URL
+        appServerServiceUrl = appServerServiceUrl.substring(0, appServerServiceUrl.length() - 1);
         performInitialDiscovery();
 
         String status = webDriverForPublisher.findElement(By.className("info-div"))

--- a/modules/integration/tests-ui/src/test/java/org/wso2/carbon/appmanager/integration/ui/Util/ExtendedAsserts.java
+++ b/modules/integration/tests-ui/src/test/java/org/wso2/carbon/appmanager/integration/ui/Util/ExtendedAsserts.java
@@ -34,7 +34,7 @@ public class ExtendedAsserts {
      */
     public static void assertContains(String subject, String expected, String message) {
         if (!subject.contains(expected)) {
-            fail(message);
+            fail(message +" But was :["+subject+"]");
         }
     }
 }


### PR DESCRIPTION
Automation test for the case added
e.g. https://localhost:9443/services